### PR TITLE
refactor: Refactorizacion de manejo de exepciones personalizadas

### DIFF
--- a/src/main/java/com/euphony/streaming/exception/HttpStatusProvider.java
+++ b/src/main/java/com/euphony/streaming/exception/HttpStatusProvider.java
@@ -1,0 +1,7 @@
+package com.euphony.streaming.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface HttpStatusProvider {
+    HttpStatus getHttpStatus();
+}

--- a/src/main/java/com/euphony/streaming/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/euphony/streaming/exception/advice/GlobalExceptionHandler.java
@@ -1,9 +1,7 @@
 package com.euphony.streaming.exception.advice;
 
-import com.euphony.streaming.exception.custom.UserCreationException;
-import com.euphony.streaming.exception.custom.UserDeletionException;
-import com.euphony.streaming.exception.custom.UserNotFoundException;
-import com.euphony.streaming.exception.custom.UserUpdateException;
+import com.euphony.streaming.exception.HttpStatusProvider;
+import com.euphony.streaming.exception.custom.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -15,6 +13,7 @@ import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
         Map<String, String> errors = new HashMap<>();
@@ -24,29 +23,26 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
-    @ExceptionHandler(UserCreationException.class)
-    public ResponseEntity<String> handleUserCreationException(UserCreationException ex) {
-        return new ResponseEntity<>(ex.getMessage(), ex.getHttpStatus());
-    }
-
-    @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
-    }
-
-    @ExceptionHandler(UserUpdateException.class)
-    public ResponseEntity<String> handleUserUpdateException(UserUpdateException ex) {
-        return new ResponseEntity<>(ex.getMessage(), ex.getHttpStatus());
-    }
-
-    @ExceptionHandler(UserDeletionException.class)
-    public ResponseEntity<String> handleUserDeletionException(UserDeletionException ex) {
-        return new ResponseEntity<>(ex.getMessage(), ex.getHttpStatus());
+    // Manejo de excepciones para Usuarios
+    @ExceptionHandler({
+            UserCreationException.class,
+            UserNotFoundException.class,
+            UserUpdateException.class,
+            UserDeletionException.class
+    })
+    public ResponseEntity<String> handleUserExceptions(RuntimeException ex) {
+        return new ResponseEntity<>(ex.getMessage(), getStatusFromException(ex));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleGlobalException(Exception ex) {
-        return new ResponseEntity<>("Error interno del servidor: " + ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>("Error interno del servidor. Por favor, intente más tarde.", HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
+    private HttpStatus getStatusFromException(RuntimeException ex) {
+        if (ex instanceof HttpStatusProvider) {
+            return ((HttpStatusProvider) ex).getHttpStatus();
+        }
+        return HttpStatus.BAD_REQUEST;
+    }
 }

--- a/src/main/java/com/euphony/streaming/exception/custom/UserCreationException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/UserCreationException.java
@@ -1,10 +1,11 @@
 package com.euphony.streaming.exception.custom;
 
+import com.euphony.streaming.exception.HttpStatusProvider;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class UserCreationException extends RuntimeException {
+public class UserCreationException extends RuntimeException implements HttpStatusProvider {
 
     private final HttpStatus httpStatus;
 
@@ -21,6 +22,11 @@ public class UserCreationException extends RuntimeException {
     public UserCreationException(Throwable cause, HttpStatus httpStatus) {
         super(cause);
         this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
     }
 
 }

--- a/src/main/java/com/euphony/streaming/exception/custom/UserDeletionException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/UserDeletionException.java
@@ -1,10 +1,12 @@
 package com.euphony.streaming.exception.custom;
 
+import com.euphony.streaming.exception.HttpStatusProvider;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class UserDeletionException extends RuntimeException {
+public class UserDeletionException extends RuntimeException implements HttpStatusProvider {
+
     private final HttpStatus httpStatus;
 
     public UserDeletionException(String message, HttpStatus httpStatus) {
@@ -20,5 +22,10 @@ public class UserDeletionException extends RuntimeException {
     public UserDeletionException(Throwable cause, HttpStatus httpStatus) {
         super(cause);
         this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
     }
 }

--- a/src/main/java/com/euphony/streaming/exception/custom/UserNotFoundException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/UserNotFoundException.java
@@ -1,20 +1,34 @@
 package com.euphony.streaming.exception.custom;
 
-public class UserNotFoundException extends RuntimeException{
+import com.euphony.streaming.exception.HttpStatusProvider;
+import org.springframework.http.HttpStatus;
 
-        public UserNotFoundException() {
-            super();
-        }
+public class UserNotFoundException extends RuntimeException implements HttpStatusProvider {
 
-        public UserNotFoundException(String message) {
-            super(message);
-        }
+    private final HttpStatus httpStatus;
 
-        public UserNotFoundException(String message, Throwable cause) {
-            super(message, cause);
-        }
+    public UserNotFoundException(HttpStatus httpStatus) {
+        super();
+        this.httpStatus = httpStatus;
+    }
 
-        public UserNotFoundException(Throwable cause) {
-            super(cause);
-        }
+    public UserNotFoundException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public UserNotFoundException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public UserNotFoundException(Throwable cause, HttpStatus httpStatus) {
+        super(cause);
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
 }

--- a/src/main/java/com/euphony/streaming/exception/custom/UserUpdateException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/UserUpdateException.java
@@ -1,10 +1,12 @@
 package com.euphony.streaming.exception.custom;
 
+import com.euphony.streaming.exception.HttpStatusProvider;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public class UserUpdateException extends RuntimeException {
+public class UserUpdateException extends RuntimeException implements HttpStatusProvider {
+
     private final HttpStatus httpStatus;
 
     public UserUpdateException(String message, HttpStatus httpStatus) {
@@ -20,5 +22,10 @@ public class UserUpdateException extends RuntimeException {
     public UserUpdateException(Throwable cause, HttpStatus httpStatus) {
         super(cause);
         this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
     }
 }


### PR DESCRIPTION
- Se refactorizó el  `GlobalExceptionHandler` para que un solo método se encargue de atrapar las excepciones personalizadas de usuarios.
- Se creo una interfaz `HttpStatusProvider` que obtiene el código de error para que las excepciones personalizadas usen la interfaz.