### PR TITLE
feat: Implementar gestión de géneros musicales (Issue #29)

### DIFF
--- a/src/main/java/com/euphony/streaming/controller/GenreController.java
+++ b/src/main/java/com/euphony/streaming/controller/GenreController.java
@@ -1,0 +1,111 @@
+package com.euphony.streaming.controller;
+
+import com.euphony.streaming.dto.request.GenreRequestDTO;
+import com.euphony.streaming.dto.response.GenreResponseDTO;
+import com.euphony.streaming.service.implementation.GenreServiceImpl;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/genres")
+@Tag(name = "Gestión de Géneros", description = "API para la gestión de géneros musicales")
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @__(@Lazy))
+public class GenreController {
+
+    private final GenreServiceImpl genreService;
+
+    @GetMapping("/all")
+    @Operation(summary = "Obtener todos los géneros", description = "Retorna la lista de todos los géneros musicales")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Operación exitosa", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = GenreResponseDTO.class))
+            })
+    })
+    public ResponseEntity<List<GenreResponseDTO>> getAllGenres() {
+        List<GenreResponseDTO> genres = genreService.findAllGenres();
+        return ResponseEntity.ok(genres);
+    }
+
+
+    @GetMapping("/search/{name}")
+    @Operation(summary = "Obtener un género por nombre", description = "Retorna un género musical por su nombre")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Operación exitosa", content = {
+                    @Content(mediaType = "application/json", schema = @Schema(implementation = GenreResponseDTO.class))
+            }),
+            @ApiResponse(responseCode = "404", description = "Género no encontrado", content = {
+                    @Content(mediaType = "application/json")
+            })
+    })
+    public ResponseEntity<GenreResponseDTO> getGenreByName(
+            @Parameter(description = "Nombre del género") @PathVariable String name) {
+        GenreResponseDTO genre = genreService.findGenreByName(name);
+        return ResponseEntity.ok(genre);
+    }
+
+
+    @PostMapping("/create")
+    @Operation(summary = "Crear un nuevo género", description = "Crea un nuevo género musical")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Género creado", content = {
+                    @Content(mediaType = "application/json")
+            }),
+            @ApiResponse(responseCode = "409", description = "El género ya existe", content = {
+                    @Content(mediaType = "application/json")
+            })
+    })
+    public ResponseEntity<Void> createGenre(
+            @Parameter(description = "Datos del nuevo género") @RequestBody GenreRequestDTO genreRequestDTO) {
+        genreService.createGenre(genreRequestDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+
+    @PutMapping("/update/{id}")
+    @Operation(summary = "Actualizar un género", description = "Actualiza un género existente")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Género actualizado", content = {
+                    @Content(mediaType = "application/json")
+            }),
+            @ApiResponse(responseCode = "404", description = "Género no encontrado", content = {
+                    @Content(mediaType = "application/json")
+            })
+    })
+    public ResponseEntity<Void> updateGenre(
+            @Parameter(description = "ID del género") @PathVariable Long id,
+            @Parameter(description = "Datos actualizados del género") @RequestBody GenreRequestDTO genreRequestDTO) {
+        genreService.updateGenre(id, genreRequestDTO);
+        return ResponseEntity.ok().build();
+    }
+
+
+    @DeleteMapping("/delete/{id}")
+    @Operation(summary = "Eliminar un género", description = "Elimina un género existente")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Género eliminado", content = {
+                    @Content(mediaType = "application/json")
+            }),
+            @ApiResponse(responseCode = "404", description = "Género no encontrado", content = {
+                    @Content(mediaType = "application/json")
+            })
+    })
+    public ResponseEntity<Void> deleteGenre(
+            @Parameter(description = "ID del género") @PathVariable Long id) {
+        genreService.deleteGenre(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/euphony/streaming/controller/PlaylistController.java
+++ b/src/main/java/com/euphony/streaming/controller/PlaylistController.java
@@ -2,9 +2,7 @@ package com.euphony.streaming.controller;
 
 import com.euphony.streaming.dto.request.PlaylistRequestDTO;
 import com.euphony.streaming.dto.response.PlaylistResponseDTO;
-import com.euphony.streaming.exception.custom.*;
 import com.euphony.streaming.service.implementation.PlaylistServiceImpl;
-import com.euphony.streaming.service.interfaces.IPlaylistService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;

--- a/src/main/java/com/euphony/streaming/dto/request/GenreRequestDTO.java
+++ b/src/main/java/com/euphony/streaming/dto/request/GenreRequestDTO.java
@@ -1,0 +1,22 @@
+package com.euphony.streaming.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO para creación y actualización de géneros")
+public class GenreRequestDTO {
+
+    @Schema(description = "Nombre del género", example = "Rock")
+    private String name;
+
+    @Schema(description = "Descripción del género", example = "Género musical que se caracteriza por su ritmo y melodía")
+    private String description;
+
+}

--- a/src/main/java/com/euphony/streaming/dto/response/GenreResponseDTO.java
+++ b/src/main/java/com/euphony/streaming/dto/response/GenreResponseDTO.java
@@ -1,0 +1,24 @@
+package com.euphony.streaming.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "DTO de respuesta que contiene la información del genero musical.")
+public class GenreResponseDTO {
+
+        @Schema(description = "ID único del género", example = "1")
+        private Long idGenre;
+
+        @Schema(description = "Nombre del género", example = "Rock")
+        private String name;
+
+        @Schema(description = "Descripción del género", example = "Género musical que se caracteriza por su ritmo y melodía")
+        private String description;
+}

--- a/src/main/java/com/euphony/streaming/exception/custom/genre/GenreCreationException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/genre/GenreCreationException.java
@@ -1,0 +1,29 @@
+package com.euphony.streaming.exception.custom.genre;
+
+import com.euphony.streaming.exception.HttpStatusProvider;
+import org.springframework.http.HttpStatus;
+
+public class GenreCreationException extends RuntimeException implements HttpStatusProvider {
+
+    private final HttpStatus httpStatus;
+
+    public GenreCreationException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public GenreCreationException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public GenreCreationException(Throwable cause, HttpStatus httpStatus) {
+        super(cause);
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/euphony/streaming/exception/custom/genre/GenreDeletionException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/genre/GenreDeletionException.java
@@ -1,0 +1,29 @@
+package com.euphony.streaming.exception.custom.genre;
+
+import com.euphony.streaming.exception.HttpStatusProvider;
+import org.springframework.http.HttpStatus;
+
+public class GenreDeletionException extends RuntimeException implements HttpStatusProvider {
+
+    private final HttpStatus httpStatus;
+
+    public GenreDeletionException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public GenreDeletionException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public GenreDeletionException(Throwable cause, HttpStatus httpStatus) {
+        super(cause);
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/euphony/streaming/exception/custom/genre/GenreNotFoundException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/genre/GenreNotFoundException.java
@@ -1,0 +1,29 @@
+package com.euphony.streaming.exception.custom.genre;
+
+import com.euphony.streaming.exception.HttpStatusProvider;
+import org.springframework.http.HttpStatus;
+
+public class GenreNotFoundException extends RuntimeException implements HttpStatusProvider {
+
+    private final HttpStatus httpStatus;
+
+    public GenreNotFoundException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public GenreNotFoundException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public GenreNotFoundException(Throwable cause, HttpStatus httpStatus) {
+        super(cause);
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/euphony/streaming/exception/custom/genre/GenreUpdateException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/genre/GenreUpdateException.java
@@ -1,0 +1,29 @@
+package com.euphony.streaming.exception.custom.genre;
+
+import com.euphony.streaming.exception.HttpStatusProvider;
+import org.springframework.http.HttpStatus;
+
+public class GenreUpdateException extends RuntimeException implements HttpStatusProvider {
+
+    private final HttpStatus httpStatus;
+
+    public GenreUpdateException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public GenreUpdateException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public GenreUpdateException(Throwable cause, HttpStatus httpStatus) {
+        super(cause);
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/euphony/streaming/repository/GeneroRepository.java
+++ b/src/main/java/com/euphony/streaming/repository/GeneroRepository.java
@@ -3,7 +3,9 @@ package com.euphony.streaming.repository;
 import com.euphony.streaming.entity.GeneroEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface GeneroRepository extends JpaRepository<GeneroEntity, Long> {
-    GeneroEntity findByNombre(String nombre);
+    Optional<GeneroEntity> findByNombre(String nombre);
     Boolean existsByNombre(String nombre);
 }

--- a/src/main/java/com/euphony/streaming/service/implementation/GenreServiceImpl.java
+++ b/src/main/java/com/euphony/streaming/service/implementation/GenreServiceImpl.java
@@ -1,0 +1,91 @@
+package com.euphony.streaming.service.implementation;
+
+import com.euphony.streaming.dto.request.GenreRequestDTO;
+import com.euphony.streaming.dto.response.GenreResponseDTO;
+import com.euphony.streaming.entity.GeneroEntity;
+import com.euphony.streaming.exception.custom.genre.GenreCreationException;
+import com.euphony.streaming.exception.custom.genre.GenreNotFoundException;
+import com.euphony.streaming.repository.GeneroRepository;
+import com.euphony.streaming.service.interfaces.IGenreService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @__(@Lazy))
+public class GenreServiceImpl implements IGenreService {
+
+    private final GeneroRepository generoRepository;
+
+
+    @Override
+    public List<GenreResponseDTO> findAllGenres() {
+        return generoRepository.findAll().stream()
+                .map(this::mapToGenreResponseDTO)
+                .toList();
+    }
+
+    @Override
+    public GenreResponseDTO findGenreByName(String name) {
+        return generoRepository.findByNombre(name)
+                .map(this::mapToGenreResponseDTO)
+                .orElseThrow(() -> new GenreNotFoundException("Género no encontrado con nombre: " + name, HttpStatus.NOT_FOUND));
+    }
+
+    @Override
+    public void createGenre(GenreRequestDTO genreRequestDTO) {
+        if (Boolean.TRUE.equals(generoRepository.existsByNombre(genreRequestDTO.getName()))) {
+            throw new GenreCreationException("El género ya existe", HttpStatus.CONFLICT);
+        }
+
+        GeneroEntity generoEntity = new GeneroEntity();
+
+        // Validar que el nombre no esté vacío
+        if (genreRequestDTO.getName() == null || genreRequestDTO.getName().isBlank()) {
+            throw new GenreCreationException("El nombre del género no puede estar vacío", HttpStatus.BAD_REQUEST);
+        }
+
+        generoEntity.setNombre(genreRequestDTO.getName());
+        generoEntity.setDescripcion(genreRequestDTO.getDescription());
+
+        generoRepository.save(generoEntity);
+    }
+
+    @Override
+    public void updateGenre(Long id, GenreRequestDTO genreRequestDTO) {
+        Optional<GeneroEntity> generoEntityOptional = generoRepository.findById(id);
+        if (generoEntityOptional.isEmpty()) {
+            throw new GenreNotFoundException("Género no encontrado con id: " + id, HttpStatus.NOT_FOUND);
+        }
+
+        // Si hay algún campo vacío, se mantiene el valor anterior
+        GeneroEntity generoEntity = generoEntityOptional.get();
+        generoEntity.setNombre(genreRequestDTO.getName() != null ? genreRequestDTO.getName() : generoEntity.getNombre());
+        generoEntity.setDescripcion(genreRequestDTO.getDescription() != null ? genreRequestDTO.getDescription() : generoEntity.getDescripcion());
+
+        generoRepository.save(generoEntity);
+    }
+
+    @Override
+    public void deleteGenre(Long id) {
+        if (!generoRepository.existsById(id)) {
+            throw new GenreNotFoundException("Género no encontrado con id: " + id, HttpStatus.NOT_FOUND);
+        }
+
+        generoRepository.deleteById(id);
+    }
+
+    private GenreResponseDTO mapToGenreResponseDTO(GeneroEntity generoEntity) {
+        return GenreResponseDTO.builder()
+                .idGenre(generoEntity.getIdGenero())
+                .name(generoEntity.getNombre())
+                .description(generoEntity.getDescripcion())
+                .build();
+    }
+}

--- a/src/main/java/com/euphony/streaming/service/interfaces/IGenreService.java
+++ b/src/main/java/com/euphony/streaming/service/interfaces/IGenreService.java
@@ -1,0 +1,49 @@
+package com.euphony.streaming.service.interfaces;
+
+import com.euphony.streaming.dto.request.GenreRequestDTO;
+import com.euphony.streaming.dto.response.GenreResponseDTO;
+
+import java.util.List;
+
+/**
+ * Interfaz que define las operaciones de gestión de géneros musicales.
+ */
+public interface IGenreService {
+
+    /**
+     * Obtiene todos los géneros musicales registrados en el sistema.
+     *
+     * @return Lista de {@link GenreResponseDTO} con la información de todos los géneros musicales.
+     */
+    List<GenreResponseDTO> findAllGenres();
+
+    /**
+     * Obtiene información de un género musical específico por su Nombre.
+     *
+     * @param name El nombre del género musical.
+     * @return Un {@link GenreResponseDTO} con los datos del género musical.
+     */
+    GenreResponseDTO findGenreByName(String name);
+
+    /**
+     * Crea un nuevo género musical en el sistema.
+     *
+     * @param genreRequestDTO Un objeto {@link GenreRequestDTO} con los datos del nuevo género musical.
+     */
+    void createGenre(GenreRequestDTO genreRequestDTO);
+
+    /**
+     * Actualiza los datos de un género musical existente.
+     *
+     * @param id El identificador único del género musical a actualizar.
+     * @param genreRequestDTO Un objeto {@link GenreRequestDTO} con los datos actualizados.
+     */
+    void updateGenre(Long id, GenreRequestDTO genreRequestDTO);
+
+    /**
+     * Elimina un género musical del sistema.
+     *
+     * @param id El identificador único del género musical a eliminar.
+     */
+    void deleteGenre(Long id);
+}


### PR DESCRIPTION
- Se desarrollo la API REST para gestionar los generos musicales.
- Se documento la API con Swagger.
- Se crearon los DTOs de solicitud y respuesta para los géneros.
- Se crearon excepciones personalizadas para los escenarios de error relacionados con los generos.
- Se creo la interfaz y la clase de implementacion para el servicio de gestion de géneros.