### PR TITLE
feat: implementar funcionalidad de seguimiento de artistas (Issue #33)

### DIFF
--- a/src/main/java/com/euphony/streaming/controller/FollowersController.java
+++ b/src/main/java/com/euphony/streaming/controller/FollowersController.java
@@ -1,0 +1,149 @@
+package com.euphony.streaming.controller;
+
+import com.euphony.streaming.dto.request.FollowersArtistRequestDTO;
+import com.euphony.streaming.dto.response.FollowersArtistResponseDTO;
+import com.euphony.streaming.service.interfaces.IFollowersService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Controlador REST que gestiona las operaciones relacionadas con los seguidores de artistas.
+ */
+@RestController
+@RequestMapping("/api/v1/followers")
+@Tag(name = "Gestión de Seguidores", description = "API para gestionar seguidores de artistas")
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @__(@Lazy))
+@Validated
+public class FollowersController {
+
+    private final IFollowersService followersService;
+
+    @Operation(
+            summary = "Seguir a un artista",
+            description = "Permite a un usuario seguir a un artista específico"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Usuario ahora sigue al artista"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Solicitud inválida"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Usuario o artista no encontrado"
+            )
+    })
+    @PostMapping("/follow")
+    public ResponseEntity<FollowersArtistResponseDTO> followArtist(
+            @RequestBody @Validated FollowersArtistRequestDTO request
+    ) {
+        log.debug("REST request para seguir artista: {}", request);
+        followersService.followArtist(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Operation(
+            summary = "Dejar de seguir a un artista",
+            description = "Permite a un usuario dejar de seguir a un artista específico"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Usuario ha dejado de seguir al artista"
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Solicitud inválida"
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Usuario o artista no encontrado"
+            )
+    })
+    @DeleteMapping("/unfollow")
+    public ResponseEntity<FollowersArtistResponseDTO> unfollowArtist(
+            @RequestBody @Validated FollowersArtistRequestDTO request
+    ) {
+        log.debug("REST request para dejar de seguir artista: {}", request);
+        followersService.unfollowArtist(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(
+            summary = "Obtener seguidores de un artista",
+            description = "Recupera la lista de usuarios que siguen a un artista específico"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Lista de seguidores recuperada exitosamente",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FollowersArtistResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Artista no encontrado",
+                    content = @Content
+            )
+    })
+    @GetMapping("/by-artist/{artistId}")
+    public ResponseEntity<List<FollowersArtistResponseDTO>> getFollowersByArtist(
+            @Parameter(description = "ID del artista", required = true)
+            @PathVariable Long artistId
+    ) {
+        log.debug("REST request para obtener seguidores del artista ID: {}", artistId);
+        List<FollowersArtistResponseDTO> followers = followersService.getFollowersByArtist(artistId);
+        return ResponseEntity.ok(followers);
+    }
+
+    @Operation(
+            summary = "Obtener artistas seguidos por un usuario",
+            description = "Recupera la lista de artistas que un usuario específico sigue"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Lista de artistas seguidos recuperada exitosamente",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = FollowersArtistResponseDTO.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Usuario no encontrado",
+                    content = @Content
+            )
+    })
+    @GetMapping("/by-user/{userId}")
+    public ResponseEntity<List<FollowersArtistResponseDTO>> getFollowersByUser(
+            @Parameter(description = "ID del usuario", required = true)
+            @PathVariable UUID userId
+    ) {
+        log.debug("REST request para obtener artistas seguidos por el usuario ID: {}", userId);
+        List<FollowersArtistResponseDTO> following = followersService.getFollowersByUser(userId);
+        return ResponseEntity.ok(following);
+    }
+}

--- a/src/main/java/com/euphony/streaming/dto/request/FollowersArtistRequestDTO.java
+++ b/src/main/java/com/euphony/streaming/dto/request/FollowersArtistRequestDTO.java
@@ -1,0 +1,27 @@
+package com.euphony.streaming.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO para solicitudes de seguir/dejar de seguir artistas")
+public class FollowersArtistRequestDTO {
+
+    @NotNull(message = "El ID del usuario no puede ser nulo")
+    @Schema(description = "ID del usuario que realiza la acción", example = "123e4567-e89b-12d3-a456-426614174000")
+    private UUID userId;
+
+    @NotNull(message = "El ID del artista no puede ser nulo")
+    @Schema(description = "ID del artista objetivo", example = "1")
+    private Long artistId;
+
+}

--- a/src/main/java/com/euphony/streaming/dto/response/FollowersArtistResponseDTO.java
+++ b/src/main/java/com/euphony/streaming/dto/response/FollowersArtistResponseDTO.java
@@ -1,0 +1,34 @@
+package com.euphony.streaming.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO para respuestas de operaciones con seguidores")
+public class FollowersArtistResponseDTO {
+
+    @Schema(description = "ID del usuario", example = "123e4567-e89b-12d3-a456-426614174000")
+    private UUID userId;
+
+    @Schema(description = "Nombre del usuario", example = "John Doe")
+    private String userName;
+
+    @Schema(description = "ID del artista", example = "1")
+    private Long artistId;
+
+    @Schema(description = "Nombre del artista", example = "Taylor Swift")
+    private String artistName;
+
+    @Schema(description = "Fecha cuando se comenzó a seguir al artista",
+            example = "2024-03-20T15:30:00")
+    private LocalDateTime followDate;
+}

--- a/src/main/java/com/euphony/streaming/entity/SeguidoresArtistaEntity.java
+++ b/src/main/java/com/euphony/streaming/entity/SeguidoresArtistaEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
@@ -16,16 +17,17 @@ import java.time.LocalDateTime;
 public class SeguidoresArtistaEntity {
 
     @Id
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_usuario", nullable = false)
     private UsuarioEntity usuario;
 
     @Id
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "id_artista", nullable = false)
     private ArtistaEntity artista;
 
-    @Column(name = "fecha_seguimiento", nullable = false)
+    @Column(name = "fecha_seguimiento", nullable = false, updatable = false)
+    @CreatedDate
     private LocalDateTime fechaSeguimiento;
 
 }

--- a/src/main/java/com/euphony/streaming/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/euphony/streaming/exception/advice/GlobalExceptionHandler.java
@@ -5,6 +5,9 @@ import com.euphony.streaming.exception.custom.artist.ArtistCreationException;
 import com.euphony.streaming.exception.custom.artist.ArtistDeletionException;
 import com.euphony.streaming.exception.custom.artist.ArtistNotFoundException;
 import com.euphony.streaming.exception.custom.artist.ArtistUpdateException;
+import com.euphony.streaming.exception.custom.follow.FollowAlreadyExistsException;
+import com.euphony.streaming.exception.custom.follow.FollowBadRequestException;
+import com.euphony.streaming.exception.custom.follow.FollowNotFoundException;
 import com.euphony.streaming.exception.custom.genre.GenreCreationException;
 import com.euphony.streaming.exception.custom.genre.GenreDeletionException;
 import com.euphony.streaming.exception.custom.genre.GenreNotFoundException;
@@ -79,6 +82,16 @@ public class GlobalExceptionHandler {
             ArtistDeletionException.class,
     })
     public ResponseEntity<String> handleArtistExceptions(RuntimeException ex) {
+        return new ResponseEntity<>(ex.getMessage(), getStatusFromException(ex));
+    }
+
+    // Manejo de excepciones para Seguidores
+    @ExceptionHandler({
+            FollowAlreadyExistsException.class,
+            FollowBadRequestException.class,
+            FollowNotFoundException.class
+    })
+    public ResponseEntity<String> handleFollowExceptions(RuntimeException ex) {
         return new ResponseEntity<>(ex.getMessage(), getStatusFromException(ex));
     }
 

--- a/src/main/java/com/euphony/streaming/exception/custom/follow/FollowAlreadyExistsException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/follow/FollowAlreadyExistsException.java
@@ -1,0 +1,29 @@
+package com.euphony.streaming.exception.custom.follow;
+
+import com.euphony.streaming.exception.HttpStatusProvider;
+import org.springframework.http.HttpStatus;
+
+public class FollowAlreadyExistsException extends RuntimeException implements HttpStatusProvider {
+
+    private final HttpStatus httpStatus;
+
+    public FollowAlreadyExistsException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public FollowAlreadyExistsException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public FollowAlreadyExistsException(Throwable cause, HttpStatus httpStatus) {
+        super(cause);
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/euphony/streaming/exception/custom/follow/FollowBadRequestException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/follow/FollowBadRequestException.java
@@ -1,0 +1,29 @@
+package com.euphony.streaming.exception.custom.follow;
+
+import com.euphony.streaming.exception.HttpStatusProvider;
+import org.springframework.http.HttpStatus;
+
+public class FollowBadRequestException extends RuntimeException implements HttpStatusProvider {
+
+    private final HttpStatus httpStatus;
+
+    public FollowBadRequestException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public FollowBadRequestException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public FollowBadRequestException(Throwable cause, HttpStatus httpStatus) {
+        super(cause);
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/euphony/streaming/exception/custom/follow/FollowNotFoundException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/follow/FollowNotFoundException.java
@@ -1,0 +1,29 @@
+package com.euphony.streaming.exception.custom.follow;
+
+import com.euphony.streaming.exception.HttpStatusProvider;
+import org.springframework.http.HttpStatus;
+
+public class FollowNotFoundException extends RuntimeException implements HttpStatusProvider {
+
+    private final HttpStatus httpStatus;
+
+    public FollowNotFoundException(String message, HttpStatus httpStatus) {
+        super(message);
+        this.httpStatus = httpStatus;
+    }
+
+    public FollowNotFoundException(String message, Throwable cause, HttpStatus httpStatus) {
+        super(message, cause);
+        this.httpStatus = httpStatus;
+    }
+
+    public FollowNotFoundException(Throwable cause, HttpStatus httpStatus) {
+        super(cause);
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/euphony/streaming/repository/SeguidoresArtistaRepository.java
+++ b/src/main/java/com/euphony/streaming/repository/SeguidoresArtistaRepository.java
@@ -3,5 +3,13 @@ package com.euphony.streaming.repository;
 import com.euphony.streaming.entity.SeguidoresArtistaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.UUID;
+
 public interface SeguidoresArtistaRepository extends JpaRepository<SeguidoresArtistaEntity, Long> {
+
+    List<SeguidoresArtistaEntity> findByUsuario_IdUsuario(UUID usuarioId);
+    List<SeguidoresArtistaEntity> findByArtista_IdArtista(Long artistaId);
+    boolean existsByUsuarioIdUsuarioAndArtistaIdArtista(UUID usuarioId, Long artistaId);
+    void deleteByUsuarioIdUsuarioAndArtistaIdArtista(UUID usuarioId, Long artistaId);
 }

--- a/src/main/java/com/euphony/streaming/service/implementation/FollowersServiceImpl.java
+++ b/src/main/java/com/euphony/streaming/service/implementation/FollowersServiceImpl.java
@@ -1,0 +1,222 @@
+package com.euphony.streaming.service.implementation;
+
+import com.euphony.streaming.dto.request.FollowersArtistRequestDTO;
+import com.euphony.streaming.dto.response.FollowersArtistResponseDTO;
+import com.euphony.streaming.entity.SeguidoresArtistaEntity;
+import com.euphony.streaming.exception.custom.artist.ArtistNotFoundException;
+import com.euphony.streaming.exception.custom.follow.FollowAlreadyExistsException;
+import com.euphony.streaming.exception.custom.follow.FollowBadRequestException;
+import com.euphony.streaming.exception.custom.follow.FollowNotFoundException;
+import com.euphony.streaming.exception.custom.user.UserNotFoundException;
+import com.euphony.streaming.repository.ArtistaRepository;
+import com.euphony.streaming.repository.SeguidoresArtistaRepository;
+import com.euphony.streaming.repository.UsuarioRepository;
+import com.euphony.streaming.service.interfaces.IFollowersService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Servicio que gestiona las operaciones de seguidores entre usuarios y artistas.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @__(@Lazy))
+public class FollowersServiceImpl implements IFollowersService {
+
+    private static final String USUARIO_NO_ENCONTRADO = "No se encontró el usuario con ID: %s";
+    private static final String ARTISTA_NO_ENCONTRADO = "No se encontró el artista con ID: %d";
+    private static final String USUARIO_YA_SIGUE = "El usuario con ID: %s ya sigue al artista con ID: %d";
+    private static final String USUARIO_NO_SIGUE = "El usuario con ID: %s no sigue al artista con ID: %d";
+    private static final String ID_USUARIO_NULO = "El ID del usuario no puede ser nulo";
+    private static final String ID_ARTISTA_INVALIDO = "El ID del artista debe ser un número positivo";
+    private static final String REQUEST_NULO = "La solicitud no puede ser nula";
+
+    private final SeguidoresArtistaRepository seguidoresArtistaRepository;
+    private final ArtistaRepository artistaRepository;
+    private final UsuarioRepository usuarioRepository;
+
+    @Transactional
+    @Override
+    public void followArtist(FollowersArtistRequestDTO request) {
+        log.debug("Iniciando proceso de seguir artista. Usuario ID: {}, Artista ID: {}",
+                request.getUserId(), request.getArtistId());
+
+        try {
+            validateRequest(request);
+            validateUserAndArtistExist(request.getUserId(), request.getArtistId());
+
+            if (isAlreadyFollowing(request.getUserId(), request.getArtistId())) {
+                String errorMessage = String.format(USUARIO_YA_SIGUE, request.getUserId(), request.getArtistId());
+                log.warn(errorMessage);
+                throw new FollowAlreadyExistsException(errorMessage, HttpStatus.CONFLICT);
+            }
+
+            createAndSaveFollowEntity(request);
+            log.info("Usuario {} ahora sigue al artista {}", request.getUserId(), request.getArtistId());
+
+        } catch (Exception e) {
+            log.error("Error al seguir artista: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Transactional
+    @Override
+    public void unfollowArtist(FollowersArtistRequestDTO request) {
+        log.debug("Iniciando proceso de dejar de seguir artista. Usuario ID: {}, Artista ID: {}",
+                request.getUserId(), request.getArtistId());
+
+        try {
+            validateRequest(request);
+            validateUserAndArtistExist(request.getUserId(), request.getArtistId());
+
+            if (!isAlreadyFollowing(request.getUserId(), request.getArtistId())) {
+                String errorMessage = String.format(USUARIO_NO_SIGUE, request.getUserId(), request.getArtistId());
+                log.warn(errorMessage);
+                throw new FollowNotFoundException(errorMessage, HttpStatus.NOT_FOUND);
+            }
+
+            deleteFollowRelation(request.getUserId(), request.getArtistId());
+            log.info("Usuario {} ha dejado de seguir al artista {}", request.getUserId(), request.getArtistId());
+
+        } catch (Exception e) {
+            log.error("Error al dejar de seguir artista: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    public List<FollowersArtistResponseDTO> getFollowersByArtist(Long artistId) {
+        log.debug("Obteniendo seguidores para el artista ID: {}", artistId);
+        try {
+            validateArtistId(artistId);
+            validateArtistExists(artistId);
+
+            List<FollowersArtistResponseDTO> followers = seguidoresArtistaRepository
+                    .findByArtista_IdArtista(artistId)
+                    .stream()
+                    .map(this::mapToFollowersResponseDTO)
+                    .toList();
+
+            log.info("Se encontraron {} seguidores para el artista {}", followers.size(), artistId);
+            return followers;
+
+        } catch (Exception e) {
+            log.error("Error al obtener seguidores del artista: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    public List<FollowersArtistResponseDTO> getFollowersByUser(UUID userId) {
+        log.debug("Obteniendo artistas seguidos por el usuario ID: {}", userId);
+        try {
+            validateUserId(userId);
+            validateUserExists(userId);
+
+            List<FollowersArtistResponseDTO> following = seguidoresArtistaRepository
+                    .findByUsuario_IdUsuario(userId)
+                    .stream()
+                    .map(this::mapToFollowersResponseDTO)
+                    .toList();
+
+            log.info("Se encontraron {} artistas seguidos por el usuario {}", following.size(), userId);
+            return following;
+
+        } catch (Exception e) {
+            log.error("Error al obtener artistas seguidos por el usuario: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    private void validateRequest(FollowersArtistRequestDTO request) {
+        if (request == null) {
+            log.error("La solicitud es nula");
+            throw new FollowBadRequestException(REQUEST_NULO, HttpStatus.BAD_REQUEST);
+        }
+        validateUserId(request.getUserId());
+        validateArtistId(request.getArtistId());
+    }
+
+    private void validateUserId(UUID userId) {
+        if (userId == null) {
+            log.error("El ID del usuario es nulo");
+            throw new FollowBadRequestException(ID_USUARIO_NULO, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateArtistId(Long artistId) {
+        if (artistId == null || artistId <= 0) {
+            log.error("El ID del artista es inválido: {}", artistId);
+            throw new FollowBadRequestException(ID_ARTISTA_INVALIDO, HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateUserAndArtistExist(UUID userId, Long artistId) {
+        validateUserExists(userId);
+        validateArtistExists(artistId);
+    }
+
+    private void validateUserExists(UUID userId) {
+        if (!usuarioRepository.existsById(userId)) {
+            String errorMessage = String.format(USUARIO_NO_ENCONTRADO, userId);
+            log.error(errorMessage);
+            throw new UserNotFoundException(errorMessage, HttpStatus.NOT_FOUND);
+        }
+    }
+
+    private void validateArtistExists(Long artistId) {
+        if (!artistaRepository.existsById(artistId)) {
+            String errorMessage = String.format(ARTISTA_NO_ENCONTRADO, artistId);
+            log.error(errorMessage);
+            throw new ArtistNotFoundException(errorMessage, HttpStatus.NOT_FOUND);
+        }
+    }
+
+    private boolean isAlreadyFollowing(UUID userId, Long artistId) {
+        return seguidoresArtistaRepository
+                .existsByUsuarioIdUsuarioAndArtistaIdArtista(userId, artistId);
+    }
+
+    private void createAndSaveFollowEntity(FollowersArtistRequestDTO request) {
+        try {
+            SeguidoresArtistaEntity followEntity = new SeguidoresArtistaEntity();
+            followEntity.setUsuario(usuarioRepository.getReferenceById(request.getUserId()));
+            followEntity.setArtista(artistaRepository.getReferenceById(request.getArtistId()));
+            followEntity.setFechaSeguimiento(LocalDateTime.now());
+
+            seguidoresArtistaRepository.save(followEntity);
+        } catch (Exception e) {
+            log.error("Error al crear y guardar la relación de seguimiento: {}", e.getMessage());
+            throw new FollowBadRequestException("Error al crear la relación de seguimiento", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void deleteFollowRelation(UUID userId, Long artistId) {
+        try {
+            seguidoresArtistaRepository
+                    .deleteByUsuarioIdUsuarioAndArtistaIdArtista(userId, artistId);
+        } catch (Exception e) {
+            log.error("Error al eliminar la relación de seguimiento: {}", e.getMessage());
+            throw new FollowBadRequestException("Error al eliminar la relación de seguimiento", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private FollowersArtistResponseDTO mapToFollowersResponseDTO(SeguidoresArtistaEntity entity) {
+        return FollowersArtistResponseDTO.builder()
+                .userId(entity.getUsuario().getIdUsuario())
+                .userName(entity.getUsuario().getNombre())
+                .artistId(entity.getArtista().getIdArtista())
+                .artistName(entity.getArtista().getNombre())
+                .followDate(entity.getFechaSeguimiento())
+                .build();
+    }
+}

--- a/src/main/java/com/euphony/streaming/service/interfaces/IFollowersService.java
+++ b/src/main/java/com/euphony/streaming/service/interfaces/IFollowersService.java
@@ -1,0 +1,43 @@
+package com.euphony.streaming.service.interfaces;
+
+import com.euphony.streaming.dto.request.FollowersArtistRequestDTO;
+import com.euphony.streaming.dto.response.FollowersArtistResponseDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Interfaz que define las operaciones disponibles para el servicio de seguidores.
+ */
+public interface IFollowersService {
+
+    /**
+     * Permite a un usuario seguir a un artista.
+     *
+     * @param request DTO con la información del usuario y artista
+     */
+    void followArtist(FollowersArtistRequestDTO request);
+
+    /**
+     * Permite a un usuario dejar de seguir a un artista.
+     *
+     * @param request DTO con la información del usuario y artista
+     */
+    void unfollowArtist(FollowersArtistRequestDTO request);
+
+    /**
+     * Obtiene la lista de seguidores de un artista.
+     *
+     * @param artistId ID del artista
+     * @return Lista de DTOs con la información de los seguidores
+     */
+    List<FollowersArtistResponseDTO> getFollowersByArtist(Long artistId);
+
+    /**
+     * Obtiene la lista de artistas que sigue un usuario.
+     *
+     * @param userId ID del usuario
+     * @return Lista de DTOs con la información de los artistas seguidos
+     */
+    List<FollowersArtistResponseDTO> getFollowersByUser(UUID userId);
+}


### PR DESCRIPTION
Se implementaron las siguientes funcionalidades:
- Seguir artista con validación de existencia y duplicados
- Dejar de seguir artista con validación de relación
- Consultar seguidores de un artista
- Consultar artistas seguidos por usuario
- Registro de timestamp al crear seguimiento