### PR TITLE
feat: implementar servicio automatico de verificacion de artistas (Issue #38)

### DIFF
--- a/src/main/java/com/euphony/streaming/StreamingApplication.java
+++ b/src/main/java/com/euphony/streaming/StreamingApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableJpaRepositories
+@EnableScheduling
 public class StreamingApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/euphony/streaming/entity/ArtistaEntity.java
+++ b/src/main/java/com/euphony/streaming/entity/ArtistaEntity.java
@@ -6,7 +6,10 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Getter
@@ -14,6 +17,7 @@ import java.util.Map;
 @NoArgsConstructor
 @Entity
 @Table(name = "ARTISTA")
+@EntityListeners(AuditingEntityListener.class)
 public class ArtistaEntity {
 
     @Id
@@ -36,4 +40,11 @@ public class ArtistaEntity {
 
     @Column(name = "is_verified", nullable = false)
     private Boolean isVerified = false;
+
+    @Column(name = "verification_date")
+    @CreatedDate
+    private LocalDateTime verificationDate;
+
+    @Column(name = "verification_reason", length = 500)
+    private String verificationReason;
 }

--- a/src/main/java/com/euphony/streaming/entity/NotificacionesArtistaEntity.java
+++ b/src/main/java/com/euphony/streaming/entity/NotificacionesArtistaEntity.java
@@ -1,0 +1,40 @@
+package com.euphony.streaming.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Entity
+@Table(name = "NOTIFICACIONES_ARTISTA")
+public class NotificacionesArtistaEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_notificacion")
+    private Long idNotificacion;
+
+    @ManyToOne
+    @JoinColumn(name = "id_artista", nullable = false)
+    private ArtistaEntity artista;
+
+    @Column(name = "titulo", nullable = false, length = 255)
+    private String titulo;
+
+    @Column(name = "mensaje", nullable = false)
+    private String mensaje;
+
+    @Column(name = "leido", nullable = false)
+    private Boolean leido = false;
+
+    @Column(name = "fecha_envio", nullable = false)
+    @CreationTimestamp
+    private LocalDateTime fechaEnvio;
+
+}

--- a/src/main/java/com/euphony/streaming/entity/NotificacionesUsuarioEntity.java
+++ b/src/main/java/com/euphony/streaming/entity/NotificacionesUsuarioEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -11,8 +12,8 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @Entity
-@Table(name = "NOTIFICACIONES")
-public class NotificacionesEntity {
+@Table(name = "NOTIFICACIONES_USUARIO")
+public class NotificacionesUsuarioEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,13 +24,17 @@ public class NotificacionesEntity {
     @JoinColumn(name = "id_usuario", nullable = false)
     private UsuarioEntity usuario;
 
+    @Column(name = "titulo", nullable = false, length = 255)
+    private String titulo;
+
     @Column(name = "mensaje", nullable = false)
     private String mensaje;
 
     @Column(name = "leido", nullable = false)
-    private Boolean leido;
+    private Boolean leido = false;
 
     @Column(name = "fecha_envio", nullable = false)
+    @CreationTimestamp
     private LocalDateTime fechaEnvio;
 
 }

--- a/src/main/java/com/euphony/streaming/entity/SeguidoresArtistaEntity.java
+++ b/src/main/java/com/euphony/streaming/entity/SeguidoresArtistaEntity.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
@@ -12,8 +13,11 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 @Entity
-@Table(name = "SEGUIDORES_ARTISTA")
+@Table(name = "SEGUIDORES_ARTISTA", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"id_usuario", "id_artista"})
+})
 @IdClass(SeguidoresArtistaId.class)
+@EntityListeners(AuditingEntityListener.class)
 public class SeguidoresArtistaEntity {
 
     @Id

--- a/src/main/java/com/euphony/streaming/event/ArtistVerificationEvent.java
+++ b/src/main/java/com/euphony/streaming/event/ArtistVerificationEvent.java
@@ -1,0 +1,15 @@
+package com.euphony.streaming.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+
+@Data
+@AllArgsConstructor
+public class ArtistVerificationEvent {
+
+    private final Long artistId;
+    private final String artistName;
+    private final Long followersCount;
+
+}

--- a/src/main/java/com/euphony/streaming/listener/ArtistVerificationListener.java
+++ b/src/main/java/com/euphony/streaming/listener/ArtistVerificationListener.java
@@ -1,0 +1,42 @@
+package com.euphony.streaming.listener;
+
+import com.euphony.streaming.entity.ArtistaEntity;
+import com.euphony.streaming.entity.NotificacionesArtistaEntity;
+import com.euphony.streaming.event.ArtistVerificationEvent;
+import com.euphony.streaming.exception.custom.user.UserNotFoundException;
+import com.euphony.streaming.repository.ArtistaRepository;
+import com.euphony.streaming.repository.NotificacionesArtistaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArtistVerificationListener {
+
+    private final NotificacionesArtistaRepository notificacionesArtistaRepository;
+    private final ArtistaRepository artistaRepository;
+
+    @EventListener
+    public void handleArtistVerification(ArtistVerificationEvent event) {
+        log.info("Manejando evento de verificación para el artista: {}", event.getArtistName());
+
+        // Crear notificación para el artista
+        NotificacionesArtistaEntity notificacion = new NotificacionesArtistaEntity();
+        ArtistaEntity artista = artistaRepository.findById(event.getArtistId())
+                .orElseThrow(() -> new UserNotFoundException("Usuario no encontrado con ID: " + event.getArtistId(), HttpStatus.NOT_FOUND));
+
+        notificacion.setArtista(artista); // Asumiendo que el ID del artista corresponde al usuario
+        notificacion.setTitulo("¡Felicitaciones! Tu cuenta ha sido verificada");
+        notificacion.setMensaje("Tu cuenta ha sido verificada automáticamente por alcanzar " +
+                event.getFollowersCount() + " seguidores. ¡Sigue creando música!");
+
+        notificacionesArtistaRepository.save(notificacion);
+
+        log.info("Notificación de verificación creada para el artista: {}", event.getArtistName());
+    }
+}

--- a/src/main/java/com/euphony/streaming/publisher/ArtistVerificationPublisher.java
+++ b/src/main/java/com/euphony/streaming/publisher/ArtistVerificationPublisher.java
@@ -1,0 +1,26 @@
+package com.euphony.streaming.publisher;
+
+import com.euphony.streaming.event.ArtistVerificationEvent;
+import com.euphony.streaming.event.UserProfileDeletedEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@Slf4j
+public class ArtistVerificationPublisher {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+
+    public ArtistVerificationPublisher(ApplicationEventPublisher applicationEventPublisher) {
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    public void publishArtistVerification(Long artistId, String artistName, Long followersCount) {
+        log.info("Publicando evento de verificación de artista");
+        applicationEventPublisher.publishEvent(new ArtistVerificationEvent(artistId, artistName, followersCount));
+    }
+}

--- a/src/main/java/com/euphony/streaming/repository/ArtistaRepository.java
+++ b/src/main/java/com/euphony/streaming/repository/ArtistaRepository.java
@@ -3,10 +3,13 @@ package com.euphony.streaming.repository;
 import com.euphony.streaming.entity.ArtistaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ArtistaRepository extends JpaRepository<ArtistaEntity, Long> {
     Optional<ArtistaEntity> findByNombre(String nombre);
 
     Boolean existsByNombre(String nombre);
+
+    List<ArtistaEntity> findByIsVerifiedFalse();
 }

--- a/src/main/java/com/euphony/streaming/repository/NotificacionesArtistaRepository.java
+++ b/src/main/java/com/euphony/streaming/repository/NotificacionesArtistaRepository.java
@@ -1,0 +1,7 @@
+package com.euphony.streaming.repository;
+
+import com.euphony.streaming.entity.NotificacionesArtistaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificacionesArtistaRepository extends JpaRepository<NotificacionesArtistaEntity, Long> {
+}

--- a/src/main/java/com/euphony/streaming/repository/NotificacionesRepository.java
+++ b/src/main/java/com/euphony/streaming/repository/NotificacionesRepository.java
@@ -1,7 +1,0 @@
-package com.euphony.streaming.repository;
-
-import com.euphony.streaming.entity.NotificacionesEntity;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface NotificacionesRepository extends JpaRepository<NotificacionesEntity, Long> {
-}

--- a/src/main/java/com/euphony/streaming/repository/NotificacionesUsuarioRepository.java
+++ b/src/main/java/com/euphony/streaming/repository/NotificacionesUsuarioRepository.java
@@ -1,0 +1,7 @@
+package com.euphony.streaming.repository;
+
+import com.euphony.streaming.entity.NotificacionesUsuarioEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificacionesUsuarioRepository extends JpaRepository<NotificacionesUsuarioEntity, Long> {
+}

--- a/src/main/java/com/euphony/streaming/repository/SeguidoresArtistaRepository.java
+++ b/src/main/java/com/euphony/streaming/repository/SeguidoresArtistaRepository.java
@@ -1,15 +1,30 @@
 package com.euphony.streaming.repository;
 
 import com.euphony.streaming.entity.SeguidoresArtistaEntity;
+import com.euphony.streaming.util.ArtistFollowerCount;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface SeguidoresArtistaRepository extends JpaRepository<SeguidoresArtistaEntity, Long> {
 
     List<SeguidoresArtistaEntity> findByUsuario_IdUsuario(UUID usuarioId);
     List<SeguidoresArtistaEntity> findByArtista_IdArtista(Long artistaId);
-    boolean existsByUsuarioIdUsuarioAndArtistaIdArtista(UUID usuarioId, Long artistaId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    boolean existsByUsuario_IdUsuarioAndArtista_IdArtista(UUID usuarioId, Long artistaId);
     void deleteByUsuarioIdUsuarioAndArtistaIdArtista(UUID usuarioId, Long artistaId);
+
+    @Query("SELECT sa.artista.idArtista AS idArtista, COUNT(sa.usuario.idUsuario) AS followerCount " +
+            "FROM SeguidoresArtistaEntity sa " +
+            "WHERE sa.artista.isVerified = false " +
+            "GROUP BY sa.artista.idArtista " +
+            "HAVING COUNT(sa.usuario.idUsuario) >= :minFollowers")
+    List<ArtistFollowerCount> findArtistsEligibleForVerification(@Param("minFollowers") Long minFollowers);
 }

--- a/src/main/java/com/euphony/streaming/service/implementation/AutomaticArtistVerificationServiceImpl.java
+++ b/src/main/java/com/euphony/streaming/service/implementation/AutomaticArtistVerificationServiceImpl.java
@@ -1,0 +1,58 @@
+package com.euphony.streaming.service.implementation;
+
+import com.euphony.streaming.entity.ArtistaEntity;
+import com.euphony.streaming.publisher.ArtistVerificationPublisher;
+import com.euphony.streaming.repository.ArtistaRepository;
+import com.euphony.streaming.repository.SeguidoresArtistaRepository;
+import com.euphony.streaming.service.interfaces.IAutomaticArtistVerificationService;
+import com.euphony.streaming.util.ArtistFollowerCount;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor(onConstructor_ = @__(@Lazy))
+public class AutomaticArtistVerificationServiceImpl implements IAutomaticArtistVerificationService {
+
+    private final ArtistaRepository artistaRepository;
+    private final SeguidoresArtistaRepository seguidoresRepository;
+    private final ArtistVerificationPublisher artistVerificationPublisher;
+    private static final int MIN_FOLLOWERS_FOR_AUTO_VERIFICATION = 1000;
+
+    @Override
+    @Scheduled(cron = "0 0 0 * * ?") // Se ejecuta todos los días a medianoche
+    @Transactional
+    public void checkArtistsForVerification() {
+        log.info("Iniciando verificación automática de artistas...");
+
+        // Obtener solo los artistas no verificados que cumplen el criterio de seguidores
+        List<ArtistFollowerCount> eligibleArtists = seguidoresRepository.findArtistsEligibleForVerification((long) MIN_FOLLOWERS_FOR_AUTO_VERIFICATION);
+
+        eligibleArtists.forEach(artistFollowerCount -> {
+            Long artistId = artistFollowerCount.getIdArtista();
+            Long followersCount = artistFollowerCount.getFollowerCount();
+
+            // Marcar el artista como verificado
+            ArtistaEntity artist = artistaRepository.findById(artistId)
+                    .orElseThrow(() -> new RuntimeException("Artista no encontrado con ID: " + artistId));
+            artist.setIsVerified(true);
+            artist.setVerificationReason("Verificación automática por alcanzar " + followersCount + " seguidores");
+
+            artistaRepository.save(artist);
+
+            // Publicar evento de verificación
+            artistVerificationPublisher.publishArtistVerification(artistId, artist.getNombre(), followersCount);
+
+            log.info("Artista verificado automáticamente: {} con {} seguidores", artist.getNombre(), followersCount);
+        });
+
+        log.info("Proceso de verificación automática completado");
+    }
+
+}

--- a/src/main/java/com/euphony/streaming/service/implementation/FollowersServiceImpl.java
+++ b/src/main/java/com/euphony/streaming/service/implementation/FollowersServiceImpl.java
@@ -53,10 +53,13 @@ public class FollowersServiceImpl implements IFollowersService {
             validateRequest(request);
             validateUserAndArtistExist(request.getUserId(), request.getArtistId());
 
+            log.debug("Verificando si el usuario {} ya sigue al artista {}", request.getUserId(), request.getArtistId());
             if (isAlreadyFollowing(request.getUserId(), request.getArtistId())) {
                 String errorMessage = String.format(USUARIO_YA_SIGUE, request.getUserId(), request.getArtistId());
                 log.warn(errorMessage);
                 throw new FollowAlreadyExistsException(errorMessage, HttpStatus.CONFLICT);
+            } else {
+                log.debug("El usuario {} aún no sigue al artista {}", request.getUserId(), request.getArtistId());
             }
 
             createAndSaveFollowEntity(request);
@@ -182,8 +185,7 @@ public class FollowersServiceImpl implements IFollowersService {
     }
 
     private boolean isAlreadyFollowing(UUID userId, Long artistId) {
-        return seguidoresArtistaRepository
-                .existsByUsuarioIdUsuarioAndArtistaIdArtista(userId, artistId);
+        return seguidoresArtistaRepository.existsByUsuario_IdUsuarioAndArtista_IdArtista(userId, artistId);
     }
 
     private void createAndSaveFollowEntity(FollowersArtistRequestDTO request) {

--- a/src/main/java/com/euphony/streaming/service/interfaces/IAutomaticArtistVerificationService.java
+++ b/src/main/java/com/euphony/streaming/service/interfaces/IAutomaticArtistVerificationService.java
@@ -1,0 +1,8 @@
+package com.euphony.streaming.service.interfaces;
+
+
+public interface IAutomaticArtistVerificationService {
+
+
+    void checkArtistsForVerification();
+}

--- a/src/main/java/com/euphony/streaming/util/ArtistFollowerCount.java
+++ b/src/main/java/com/euphony/streaming/util/ArtistFollowerCount.java
@@ -1,0 +1,11 @@
+package com.euphony.streaming.util;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public interface ArtistFollowerCount {
+
+    Long getIdArtista();
+    Long getFollowerCount();
+
+}

--- a/src/main/resources/db/migration/V4__renombrar_notificaciones_y_agregar_titulo_y_crear_notificaciones_usuario.sql
+++ b/src/main/resources/db/migration/V4__renombrar_notificaciones_y_agregar_titulo_y_crear_notificaciones_usuario.sql
@@ -1,0 +1,29 @@
+-- 1. Renombrar la tabla NOTIFICACIONES a NOTIFICACIONES_ARTISTA
+ALTER TABLE NOTIFICACIONES RENAME TO NOTIFICACIONES_ARTISTA;
+
+-- 2. Añadir el campo 'titulo' a la tabla NOTIFICACIONES_ARTISTA
+ALTER TABLE NOTIFICACIONES_ARTISTA
+    ADD COLUMN titulo VARCHAR(255) NOT NULL DEFAULT '';
+
+-- 3. Cambiar la FOREIGN KEY de id_usuario a id_artista
+ALTER TABLE NOTIFICACIONES_ARTISTA
+DROP CONSTRAINT fk_notificaciones_usuario, -- Usar DROP CONSTRAINT en lugar de DROP FOREIGN KEY
+    DROP COLUMN id_usuario,
+    ADD COLUMN id_artista BIGINT NOT NULL,
+    ADD CONSTRAINT fk_notificaciones_artista FOREIGN KEY (id_artista) REFERENCES ARTISTA(id_artista);
+
+-- 4. Crear la nueva tabla NOTIFICACIONES_USUARIO
+CREATE TABLE NOTIFICACIONES_USUARIO (
+                                        id_notificacion_usuario SERIAL PRIMARY KEY,
+                                        id_usuario UUID NOT NULL,
+                                        titulo VARCHAR(255) NOT NULL DEFAULT '',
+                                        mensaje VARCHAR(1000) NOT NULL,
+                                        leido BOOLEAN NOT NULL DEFAULT FALSE,
+                                        fecha_envio TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                        contenido VARCHAR(1000) NOT NULL DEFAULT '',
+                                        FOREIGN KEY (id_usuario) REFERENCES USUARIO(id_usuario)
+);
+
+-- 5. Crear índices para optimizar consultas
+CREATE INDEX idx_notificaciones_artista_artista ON NOTIFICACIONES_ARTISTA(id_artista);
+CREATE INDEX idx_notificaciones_usuario_usuario ON NOTIFICACIONES_USUARIO(id_usuario);

--- a/src/main/resources/db/migration/V5__agregar_verificacion_artista.sql
+++ b/src/main/resources/db/migration/V5__agregar_verificacion_artista.sql
@@ -1,0 +1,4 @@
+-- 1. Agregar campos de verificación a la tabla ARTISTA
+ALTER TABLE ARTISTA
+    ADD COLUMN verification_date TIMESTAMP DEFAULT NULL,
+    ADD COLUMN verification_reason TEXT DEFAULT '';

--- a/src/test/java/com/euphony/streaming/service/AutomaticArtistVerificationServiceImplTest.java
+++ b/src/test/java/com/euphony/streaming/service/AutomaticArtistVerificationServiceImplTest.java
@@ -1,0 +1,115 @@
+package com.euphony.streaming.service;
+
+import com.euphony.streaming.entity.ArtistaEntity;
+import com.euphony.streaming.publisher.ArtistVerificationPublisher;
+import com.euphony.streaming.repository.ArtistaRepository;
+import com.euphony.streaming.repository.SeguidoresArtistaRepository;
+import com.euphony.streaming.service.implementation.AutomaticArtistVerificationServiceImpl;
+import com.euphony.streaming.util.ArtistFollowerCount;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+class AutomaticArtistVerificationServiceImplTest {
+
+    // Declaración de los mocks y la clase a probar
+    @Mock
+    private ArtistaRepository artistaRepository;
+
+    @Mock
+    private SeguidoresArtistaRepository seguidoresRepository;
+
+    @Mock
+    private ArtistVerificationPublisher artistVerificationPublisher;
+
+    @InjectMocks
+    private AutomaticArtistVerificationServiceImpl automaticArtistVerificationService;
+
+    @BeforeEach
+    void setUp() {
+        // Inicializa los mocks antes de cada prueba
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void checkArtistsForVerification_verifiesEligibleArtists() {
+        // Arrange
+        // Crea un objeto ArtistFollowerCount simulado
+        ArtistFollowerCount artistFollowerCount = new ArtistFollowerCount() {
+            @Override
+            public Long getIdArtista() {
+                return 1L;
+            }
+
+            @Override
+            public Long getFollowerCount() {
+                return 100L;
+            }
+        };
+        // Crea un objeto ArtistaEntity simulado
+        ArtistaEntity artist = new ArtistaEntity();
+        artist.setIdArtista(1L);
+        artist.setNombre("Jose Jose");
+        artist.setIsVerified(false);
+
+        // Configura los comportamientos simulados de los métodos
+        when(seguidoresRepository.findArtistsEligibleForVerification(anyLong())).thenReturn(List.of(artistFollowerCount));
+        when(artistaRepository.findById(1L)).thenReturn(Optional.of(artist));
+
+        // Act
+        automaticArtistVerificationService.checkArtistsForVerification();
+
+        // Assert
+        // Verifica que se hayan llamado los métodos esperados
+        verify(artistaRepository).save(artist);
+        verify(artistVerificationPublisher).publishArtistVerification(1L, "Jose Jose", 100L);
+    }
+
+    @Test
+    void checkArtistsForVerification_throwsExceptionWhenArtistNotFound() {
+        // Arrange
+        ArtistFollowerCount artistFollowerCount = new ArtistFollowerCount() {
+            @Override
+            public Long getIdArtista() {
+                return 1L;
+            }
+
+            @Override
+            public Long getFollowerCount() {
+                return 100L;
+            }
+        };
+
+        // Configura los comportamientos simulados de los métodos
+        when(seguidoresRepository.findArtistsEligibleForVerification(anyLong())).thenReturn(List.of(artistFollowerCount));
+        when(artistaRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // Assert
+        // Verifica que se lance la excepción esperada
+        assertThrows(RuntimeException.class, () -> automaticArtistVerificationService.checkArtistsForVerification());
+    }
+
+    @Test
+    void checkArtistsForVerification_noEligibleArtists() {
+        // Arrange
+        // Configura los comportamientos simulados de los métodos
+        when(seguidoresRepository.findArtistsEligibleForVerification(anyLong())).thenReturn(List.of());
+
+        // Act
+        automaticArtistVerificationService.checkArtistsForVerification();
+
+        // Assert
+        // Verifica que no se hayan llamado los métodos esperados
+        verify(artistaRepository, never()).save(any());
+        verify(artistVerificationPublisher, never()).publishArtistVerification(anyLong(), anyString(), anyLong());
+    }
+}


### PR DESCRIPTION
- Se desarrollo el servicio para verificar automaticamente a los artistas segun el numero de seguidores.
- El servicio se ejecuta todos los dias a medianoche y verifica los artistas que han alcanzado los 1000 seguidores.
- Se agrego publicacion del evento de verificacion.