### PR TITLE
fix: Correccion del método update y  se renombro la  carpeta y clases de excepciones

### DIFF
--- a/src/main/java/com/euphony/streaming/exception/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/euphony/streaming/exception/advice/GlobalExceptionHandler.java
@@ -16,10 +16,10 @@ import com.euphony.streaming.exception.custom.playlist.PlaylistCreationException
 import com.euphony.streaming.exception.custom.playlist.PlaylistDeletionException;
 import com.euphony.streaming.exception.custom.playlist.PlaylistNotFoundException;
 import com.euphony.streaming.exception.custom.playlist.PlaylistUpdateException;
-import com.euphony.streaming.exception.custom.subscription.SubscriptionCreationException;
-import com.euphony.streaming.exception.custom.subscription.SubscriptionDeletionException;
-import com.euphony.streaming.exception.custom.subscription.SubscriptionNotFoundException;
-import com.euphony.streaming.exception.custom.subscription.SubscriptionUpdateException;
+import com.euphony.streaming.exception.custom.subcriptionplans.SubscriptionPlansCreationException;
+import com.euphony.streaming.exception.custom.subcriptionplans.SubscriptionPlansDeletionException;
+import com.euphony.streaming.exception.custom.subcriptionplans.SubscriptionPlansNotFoundException;
+import com.euphony.streaming.exception.custom.subcriptionplans.SubscriptionPlansUpdateException;
 import com.euphony.streaming.exception.custom.user.UserCreationException;
 import com.euphony.streaming.exception.custom.user.UserDeletionException;
 import com.euphony.streaming.exception.custom.user.UserNotFoundException;
@@ -105,10 +105,10 @@ public class GlobalExceptionHandler {
     }
     // Manejo de excepciones para Suscripciones
     @ExceptionHandler({
-            SubscriptionCreationException.class,
-            SubscriptionNotFoundException.class,
-            SubscriptionUpdateException.class,
-            SubscriptionDeletionException.class,
+            SubscriptionPlansCreationException.class,
+            SubscriptionPlansNotFoundException.class,
+            SubscriptionPlansUpdateException.class,
+            SubscriptionPlansDeletionException.class,
     })
     public ResponseEntity<String> handleSubscriptionExceptions(RuntimeException ex) {
         return new ResponseEntity<>(ex.getMessage(), getStatusFromException(ex));

--- a/src/main/java/com/euphony/streaming/exception/custom/subcriptionplans/SubscriptionPlansCreationException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/subcriptionplans/SubscriptionPlansCreationException.java
@@ -1,23 +1,23 @@
-package com.euphony.streaming.exception.custom.subscription;
+package com.euphony.streaming.exception.custom.subcriptionplans;
 
 import com.euphony.streaming.exception.HttpStatusProvider;
 import org.springframework.http.HttpStatus;
 
-public class SubscriptionDeletionException extends RuntimeException implements HttpStatusProvider {
+public class SubscriptionPlansCreationException extends RuntimeException implements HttpStatusProvider {
 
     private final HttpStatus httpStatus;
 
-    public SubscriptionDeletionException(String message, HttpStatus httpStatus) {
+    public SubscriptionPlansCreationException(String message, HttpStatus httpStatus) {
         super(message);
         this.httpStatus = httpStatus;
     }
 
-    public SubscriptionDeletionException(String message, Throwable cause, HttpStatus httpStatus) {
+    public SubscriptionPlansCreationException(String message, Throwable cause, HttpStatus httpStatus) {
         super(message, cause);
         this.httpStatus = httpStatus;
     }
 
-    public SubscriptionDeletionException(Throwable cause, HttpStatus httpStatus) {
+    public SubscriptionPlansCreationException(Throwable cause, HttpStatus httpStatus) {
         super(cause);
         this.httpStatus = httpStatus;
     }

--- a/src/main/java/com/euphony/streaming/exception/custom/subcriptionplans/SubscriptionPlansDeletionException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/subcriptionplans/SubscriptionPlansDeletionException.java
@@ -1,23 +1,23 @@
-package com.euphony.streaming.exception.custom.subscription;
+package com.euphony.streaming.exception.custom.subcriptionplans;
 
 import com.euphony.streaming.exception.HttpStatusProvider;
 import org.springframework.http.HttpStatus;
 
-public class SubscriptionUpdateException extends RuntimeException implements HttpStatusProvider {
+public class SubscriptionPlansDeletionException extends RuntimeException implements HttpStatusProvider {
 
     private final HttpStatus httpStatus;
 
-    public SubscriptionUpdateException(String message, HttpStatus httpStatus) {
+    public SubscriptionPlansDeletionException(String message, HttpStatus httpStatus) {
         super(message);
         this.httpStatus = httpStatus;
     }
 
-    public SubscriptionUpdateException(String message, Throwable cause, HttpStatus httpStatus) {
+    public SubscriptionPlansDeletionException(String message, Throwable cause, HttpStatus httpStatus) {
         super(message, cause);
         this.httpStatus = httpStatus;
     }
 
-    public SubscriptionUpdateException(Throwable cause, HttpStatus httpStatus) {
+    public SubscriptionPlansDeletionException(Throwable cause, HttpStatus httpStatus) {
         super(cause);
         this.httpStatus = httpStatus;
     }

--- a/src/main/java/com/euphony/streaming/exception/custom/subcriptionplans/SubscriptionPlansNotFoundException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/subcriptionplans/SubscriptionPlansNotFoundException.java
@@ -1,23 +1,23 @@
-package com.euphony.streaming.exception.custom.subscription;
+package com.euphony.streaming.exception.custom.subcriptionplans;
 
 import com.euphony.streaming.exception.HttpStatusProvider;
 import org.springframework.http.HttpStatus;
 
-public class SubscriptionNotFoundException extends RuntimeException implements HttpStatusProvider {
+public class SubscriptionPlansNotFoundException extends RuntimeException implements HttpStatusProvider {
 
     private final HttpStatus httpStatus;
 
-    public SubscriptionNotFoundException(String message, HttpStatus httpStatus) {
+    public SubscriptionPlansNotFoundException(String message, HttpStatus httpStatus) {
         super(message);
         this.httpStatus = httpStatus;
     }
 
-    public SubscriptionNotFoundException(String message, Throwable cause, HttpStatus httpStatus) {
+    public SubscriptionPlansNotFoundException(String message, Throwable cause, HttpStatus httpStatus) {
         super(message, cause);
         this.httpStatus = httpStatus;
     }
 
-    public SubscriptionNotFoundException(Throwable cause, HttpStatus httpStatus) {
+    public SubscriptionPlansNotFoundException(Throwable cause, HttpStatus httpStatus) {
         super(cause);
         this.httpStatus = httpStatus;
     }

--- a/src/main/java/com/euphony/streaming/exception/custom/subcriptionplans/SubscriptionPlansUpdateException.java
+++ b/src/main/java/com/euphony/streaming/exception/custom/subcriptionplans/SubscriptionPlansUpdateException.java
@@ -1,23 +1,23 @@
-package com.euphony.streaming.exception.custom.subscription;
+package com.euphony.streaming.exception.custom.subcriptionplans;
 
 import com.euphony.streaming.exception.HttpStatusProvider;
 import org.springframework.http.HttpStatus;
 
-public class SubscriptionCreationException extends RuntimeException implements HttpStatusProvider {
+public class SubscriptionPlansUpdateException extends RuntimeException implements HttpStatusProvider {
 
     private final HttpStatus httpStatus;
 
-    public SubscriptionCreationException(String message, HttpStatus httpStatus) {
+    public SubscriptionPlansUpdateException(String message, HttpStatus httpStatus) {
         super(message);
         this.httpStatus = httpStatus;
     }
 
-    public SubscriptionCreationException(String message, Throwable cause, HttpStatus httpStatus) {
+    public SubscriptionPlansUpdateException(String message, Throwable cause, HttpStatus httpStatus) {
         super(message, cause);
         this.httpStatus = httpStatus;
     }
 
-    public SubscriptionCreationException(Throwable cause, HttpStatus httpStatus) {
+    public SubscriptionPlansUpdateException(Throwable cause, HttpStatus httpStatus) {
         super(cause);
         this.httpStatus = httpStatus;
     }


### PR DESCRIPTION
 Se refactorizó el método `update` para permitir actualización parcial sin requerir todos los campos.
- Se renombró la carpeta `subscription` a `subscriptionplans`.
- Se renombraron clases de excepciones para mejorar la consistencia de nombres:
  - `SubscriptionCreationException` a `SubscriptionPlansCreationException`
  - `SubscriptionDeletionException` a `SubscriptionPlansDeletionException`
  - `SubscriptionNotFoundException` a `SubscriptionPlansNotFoundException`
  - `SubscriptionUpdateException` a `SubscriptionPlansUpdateException`