### PR TITLE
Feature/canciones por album y artista

### DIFF
--- a/src/main/java/com/euphony/streaming/controller/SongController.java
+++ b/src/main/java/com/euphony/streaming/controller/SongController.java
@@ -99,6 +99,58 @@ public class SongController {
         return ResponseEntity.ok(songService.searchSongById(id));
     }
 
+    @GetMapping("/search/by-album/{albumId}")
+    @Operation(
+            summary = "Listar canciones por álbum",
+            description = "Recupera las canciones de un álbum específico, con artista, álbum y géneros"
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Canciones del álbum recuperadas exitosamente",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    array = @ArraySchema(schema = @Schema(implementation = SongResponseDTO.class))
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Álbum no encontrado",
+            content = @Content
+    )
+    public ResponseEntity<List<SongResponseDTO>> getSongsByAlbum(
+            @Parameter(description = "ID del álbum", required = true)
+            @PathVariable Long albumId
+    ) {
+        log.debug("REST request to get Songs by album : {}", albumId);
+        return ResponseEntity.ok(songService.findSongsByAlbum(albumId));
+    }
+
+    @GetMapping("/search/by-artist/{artistId}")
+    @Operation(
+            summary = "Listar canciones por artista",
+            description = "Recupera las canciones de un artista específico, con artista, álbum y géneros"
+    )
+    @ApiResponse(
+            responseCode = "200",
+            description = "Canciones del artista recuperadas exitosamente",
+            content = @Content(
+                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    array = @ArraySchema(schema = @Schema(implementation = SongResponseDTO.class))
+            )
+    )
+    @ApiResponse(
+            responseCode = "404",
+            description = "Artista no encontrado",
+            content = @Content
+    )
+    public ResponseEntity<List<SongResponseDTO>> getSongsByArtist(
+            @Parameter(description = "ID del artista", required = true)
+            @PathVariable Long artistId
+    ) {
+        log.debug("REST request to get Songs by artist : {}", artistId);
+        return ResponseEntity.ok(songService.findSongsByArtist(artistId));
+    }
+
     @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(
             summary = "Analizar metadatos",

--- a/src/main/java/com/euphony/streaming/repository/CancionRepository.java
+++ b/src/main/java/com/euphony/streaming/repository/CancionRepository.java
@@ -29,4 +29,24 @@ public interface CancionRepository extends JpaRepository<CancionEntity, Long> {
             "WHERE c.idCancion = :songId")
     Optional<CancionEntity> findByIdWithArtistAndAlbum(@Param("songId") Long songId);
 
+    /**
+     * Recupera las canciones de un álbum trayendo el artista y el álbum en la misma
+     * consulta mediante {@code LEFT JOIN FETCH}, evitando el problema N+1.
+     */
+    @Query("SELECT c FROM CancionEntity c " +
+            "LEFT JOIN FETCH c.artista " +
+            "LEFT JOIN FETCH c.album " +
+            "WHERE c.album.idAlbum = :albumId")
+    List<CancionEntity> findByAlbumIdWithArtistAndAlbum(@Param("albumId") Long albumId);
+
+    /**
+     * Recupera las canciones de un artista trayendo el artista y el álbum en la misma
+     * consulta mediante {@code LEFT JOIN FETCH}, evitando el problema N+1.
+     */
+    @Query("SELECT c FROM CancionEntity c " +
+            "LEFT JOIN FETCH c.artista " +
+            "LEFT JOIN FETCH c.album " +
+            "WHERE c.artista.idArtista = :artistId")
+    List<CancionEntity> findByArtistIdWithArtistAndAlbum(@Param("artistId") Long artistId);
+
 }

--- a/src/main/java/com/euphony/streaming/service/implementation/SongServiceImpl.java
+++ b/src/main/java/com/euphony/streaming/service/implementation/SongServiceImpl.java
@@ -50,22 +50,15 @@ public class SongServiceImpl implements ISongService {
     private static final String ERROR_ARTIST_NOT_FOUND = "Artista no encontrado: %s";
     private static final String ERROR_ALBUM_NOT_FOUND = "Álbum no encontrado";
     private static final String ERROR_SONG_NOT_FOUND = "Canción no encontrada con ID %d";
+    private static final String ERROR_ALBUM_NOT_FOUND_BY_ID = "Álbum no encontrado con ID %d";
+    private static final String ERROR_ARTIST_NOT_FOUND_BY_ID = "Artista no encontrado con ID %d";
 
     @Override
     @Transactional(readOnly = true)
     @Cacheable(value = "songs", key = "'all'")
     public List<SongResponseDTO> findAllSongs() {
         log.info("Buscando todas las canciones");
-        List<CancionEntity> songs = cancionRepository.findAllWithArtistAndAlbum();
-
-        // Se resuelven los géneros de todas las canciones en una sola consulta (evita N+1).
-        Map<Long, Set<String>> genresBySong = fetchGenresBySongIds(
-                songs.stream().map(CancionEntity::getIdCancion).toList());
-
-        return songs.stream()
-                .map(song -> mapToSongResponseDTO(song,
-                        genresBySong.getOrDefault(song.getIdCancion(), Set.of())))
-                .toList();
+        return toSongResponseDTOs(cancionRepository.findAllWithArtistAndAlbum());
     }
 
     @Override
@@ -79,6 +72,28 @@ public class SongServiceImpl implements ISongService {
                         String.format(ERROR_SONG_NOT_FOUND, songId),
                         HttpStatus.NOT_FOUND
                 ));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SongResponseDTO> findSongsByAlbum(Long albumId) {
+        log.info("Buscando canciones del álbum: {}", albumId);
+        if (!albumRepository.existsById(albumId)) {
+            throw new AlbumNotFoundException(
+                    String.format(ERROR_ALBUM_NOT_FOUND_BY_ID, albumId), HttpStatus.NOT_FOUND);
+        }
+        return toSongResponseDTOs(cancionRepository.findByAlbumIdWithArtistAndAlbum(albumId));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SongResponseDTO> findSongsByArtist(Long artistId) {
+        log.info("Buscando canciones del artista: {}", artistId);
+        if (!artistaRepository.existsById(artistId)) {
+            throw new ArtistNotFoundException(
+                    String.format(ERROR_ARTIST_NOT_FOUND_BY_ID, artistId), HttpStatus.NOT_FOUND);
+        }
+        return toSongResponseDTOs(cancionRepository.findByArtistIdWithArtistAndAlbum(artistId));
     }
 
     @Override
@@ -353,6 +368,20 @@ public class SongServiceImpl implements ISongService {
         songGenre.setGenero(genre);
         cancionGeneroRepository.save(songGenre);
         log.info("Género '{}' asociado a la canción '{}'", genreName, song.getTitulo());
+    }
+
+    /**
+     * Convierte una lista de canciones en sus DTOs, resolviendo los géneros de todas
+     * ellas en una sola consulta batcheada (evita N+1). Patrón compartido por los
+     * listados: todas, por álbum y por artista.
+     */
+    private List<SongResponseDTO> toSongResponseDTOs(List<CancionEntity> songs) {
+        Map<Long, Set<String>> genresBySong = fetchGenresBySongIds(
+                songs.stream().map(CancionEntity::getIdCancion).toList());
+        return songs.stream()
+                .map(song -> mapToSongResponseDTO(song,
+                        genresBySong.getOrDefault(song.getIdCancion(), Set.of())))
+                .toList();
     }
 
     /**

--- a/src/main/java/com/euphony/streaming/service/interfaces/ISongService.java
+++ b/src/main/java/com/euphony/streaming/service/interfaces/ISongService.java
@@ -66,4 +66,20 @@ public interface ISongService {
      * @return Ruta del archivo de la canción.
      */
     Path getSongFilePath(Long id);
+
+    /**
+     * Obtiene las canciones de un álbum.
+     *
+     * @param albumId El identificador único del álbum.
+     * @return Lista de {@link SongResponseDTO} de las canciones del álbum (vacía si el álbum no tiene canciones).
+     */
+    List<SongResponseDTO> findSongsByAlbum(Long albumId);
+
+    /**
+     * Obtiene las canciones de un artista.
+     *
+     * @param artistId El identificador único del artista.
+     * @return Lista de {@link SongResponseDTO} de las canciones del artista (vacía si el artista no tiene canciones).
+     */
+    List<SongResponseDTO> findSongsByArtist(Long artistId);
 }

--- a/src/test/java/com/euphony/streaming/service/SongServiceImplTest.java
+++ b/src/test/java/com/euphony/streaming/service/SongServiceImplTest.java
@@ -4,6 +4,8 @@ import com.euphony.streaming.dto.response.SongResponseDTO;
 import com.euphony.streaming.entity.AlbumEntity;
 import com.euphony.streaming.entity.ArtistaEntity;
 import com.euphony.streaming.entity.CancionEntity;
+import com.euphony.streaming.exception.custom.album.AlbumNotFoundException;
+import com.euphony.streaming.exception.custom.artist.ArtistNotFoundException;
 import com.euphony.streaming.repository.AlbumRepository;
 import com.euphony.streaming.repository.ArtistaRepository;
 import com.euphony.streaming.repository.CancionGeneroRepository;
@@ -24,6 +26,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -202,5 +205,79 @@ class SongServiceImplTest {
         assertEquals("Taylor Swift", dto.getArtistName());
         assertEquals("1989", dto.getAlbumTitle());
         assertEquals("/uploads/images/album_1989.jpg", dto.getAlbumCover());
+    }
+
+    @Test
+    void findSongsByAlbum_returnsEnrichedSongsOfThatAlbum() {
+        // Arrange
+        ArtistaEntity artist = buildArtist(1L, "Taylor Swift");
+        AlbumEntity album = buildAlbum(2L, "1989", "/uploads/images/album_1989.jpg");
+        CancionEntity song = buildSong(10L, artist, album);
+
+        when(albumRepository.existsById(2L)).thenReturn(true);
+        when(cancionRepository.findByAlbumIdWithArtistAndAlbum(2L)).thenReturn(List.of(song));
+        when(cancionGeneroRepository.findGenresByCancionIds(anyCollection()))
+                .thenReturn(List.of(genreProjection(10L, "Pop")));
+
+        // Act
+        List<SongResponseDTO> result = songService.findSongsByAlbum(2L);
+
+        // Assert
+        assertEquals(1, result.size());
+        SongResponseDTO dto = result.get(0);
+        assertEquals("Taylor Swift", dto.getArtistName());
+        assertEquals("1989", dto.getAlbumTitle());
+        assertEquals(Set.of("Pop"), dto.getGenres());
+    }
+
+    @Test
+    void findSongsByArtist_returnsSongsOfThatArtist() {
+        // Arrange
+        ArtistaEntity artist = buildArtist(1L, "Taylor Swift");
+        CancionEntity song = buildSong(10L, artist, null);
+
+        when(artistaRepository.existsById(1L)).thenReturn(true);
+        when(cancionRepository.findByArtistIdWithArtistAndAlbum(1L)).thenReturn(List.of(song));
+
+        // Act
+        List<SongResponseDTO> result = songService.findSongsByArtist(1L);
+
+        // Assert
+        assertEquals(1, result.size());
+        assertEquals("Taylor Swift", result.get(0).getArtistName());
+    }
+
+    @Test
+    void findSongsByAlbum_throwsWhenAlbumDoesNotExist() {
+        // Arrange: el álbum no existe.
+        when(albumRepository.existsById(99L)).thenReturn(false);
+
+        // Act + Assert: 404 y nunca se consultan las canciones.
+        assertThrows(AlbumNotFoundException.class, () -> songService.findSongsByAlbum(99L));
+        verify(cancionRepository, never()).findByAlbumIdWithArtistAndAlbum(anyLong());
+    }
+
+    @Test
+    void findSongsByArtist_throwsWhenArtistDoesNotExist() {
+        // Arrange: el artista no existe.
+        when(artistaRepository.existsById(99L)).thenReturn(false);
+
+        // Act + Assert: 404 y nunca se consultan las canciones.
+        assertThrows(ArtistNotFoundException.class, () -> songService.findSongsByArtist(99L));
+        verify(cancionRepository, never()).findByArtistIdWithArtistAndAlbum(anyLong());
+    }
+
+    @Test
+    void findSongsByAlbum_existingAlbumWithoutSongsReturnsEmptyAndSkipsGenreQuery() {
+        // Arrange: el álbum existe pero no tiene canciones.
+        when(albumRepository.existsById(2L)).thenReturn(true);
+        when(cancionRepository.findByAlbumIdWithArtistAndAlbum(2L)).thenReturn(List.of());
+
+        // Act
+        List<SongResponseDTO> result = songService.findSongsByAlbum(2L);
+
+        // Assert: lista vacía y la consulta de géneros nunca se ejecuta (no se genera un IN ()).
+        assertTrue(result.isEmpty());
+        verify(cancionGeneroRepository, never()).findGenresByCancionIds(anyCollection());
     }
 }


### PR DESCRIPTION
Añade dos endpoints de lectura que devuelven el SongResponseDTO
    enriquecido (artista, álbum, géneros), sin reintroducir N+1:
    
    - GET /api/v1/songs/search/by-album/{albumId}
    - GET /api/v1/songs/search/by-artist/{artistId}
      (rutas alineadas con el patrón /search/by-... del módulo de álbumes)
    
    Rendimiento: cada endpoint se resuelve en 2 consultas fijas
    (canciones con artista/álbum vía LEFT JOIN FETCH + géneros
    batcheados), independientemente del número de canciones.
    
    Se extrae el mapeo compartido (canciones -> batch de géneros -> DTO)
    a un método privado reutilizable que usan los tres listados (todas,
    por álbum y por artista), sin duplicar lógica.
    
    Bordes: álbum/artista inexistente -> 404 (texto plano); existente
    sin canciones -> 200 con lista vacía. Documentado en Swagger.